### PR TITLE
.github: use env file for storing latest Tailscale version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       TSTAG: v1.0.0
     steps:
     - name: Set Tailscale version from source
-      run: echo ::set-env name=TSTAG::$(curl https://api.github.com/repos/tailscale/tailscale/tags -s | jq ".[0].name" -r)
+      run: echo "$(curl https://api.github.com/repos/tailscale/tailscale/tags -s | jq '.[0].name' -r)" >> $GITHUB_ENV
 
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       TSTAG: v1.0.0
     steps:
     - name: Set Tailscale version from source
-      run: echo "$(curl https://api.github.com/repos/tailscale/tailscale/tags -s | jq '.[0].name' -r)" >> $GITHUB_ENV
+      run: echo "TSTAG=$(curl https://api.github.com/repos/tailscale/tailscale/tags -s | jq '.[0].name' -r)" >> $GITHUB_ENV
 
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Resolves #5 