### PR TITLE
Add support for older QNAP where QVPN is not available (e.g. TS-110)

### DIFF
--- a/build/build-qpkg.sh
+++ b/build/build-qpkg.sh
@@ -26,7 +26,7 @@ cp out/tailscale-arm64 /Tailscale/arm_64/tailscale
 mkdir -p /Tailscale/shared/var/run/tailscale
 mkdir -p /Tailscale/shared/var/lib/tailscale
 
-sed -i '/#QPKG_REQUIRE/cQPKG_REQUIRE="QVPN"' /Tailscale/qpkg.cfg
+sed -i '/#QPKG_REQUIRE/cQPKG_REQUIRE="QVPN|QL2TP-IPsecServer"' /Tailscale/qpkg.cfg
 
 sed -i '/: ADD START ACTIONS HERE/c\
     $QPKG_ROOT/tailscaled --port 41641 --state=$QPKG_ROOT/var/lib/tailscale/tailscaled.state --socket=$QPKG_ROOT/var/run/tailscale/tailscaled.sock 2> /dev/null &\


### PR DESCRIPTION
Alternate app package QL2TP-IPsecServer also adds tun.ko (https://www.qnap.com/de-de/app_releasenotes/list.php?app_choose=QL2TP-IPsecServer).